### PR TITLE
Composer: Support for SSL CA bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 # Instalace
 
-```shell
+```sh
 composer require ecomailcz/webareal-client
 ```
 
 # Použití
 
 ```php
+<?php
 $username = '<vaše přihlašovací jméno>';
-$password = '<vaše přihlašovací heaslo>';
+$password = '<vaše přihlašovací heslo>';
 $apiKey = '<váš API klíč>';
 
 $credentials = new \Ecomailcz\Webareal\Credentials($username, $password, $apiKey); 
@@ -36,6 +37,21 @@ Výchozí cache si ale ukládá Token pouze v paměti, která se po skončení b
 ukládání cache do souboru, stačí jen cache předat knihovně při vytváření:
 
 ```php
+<?php
 $cache = new \Ecomailcz\Webareal\TokenCache\FileCache(__DIR__ . '/temp');
 $api = new \Ecomailcz\Webareal\Client($credentials, $cache);
+```
+
+## SSL CA bundle
+Pokud není na serveru správně nainstalován balíček aktuálních CA certifikátů, může spojení na API server selhat s chybou:
+```plain_text
+curl: (60) SSL certificate problem: Invalid certificate chain
+More details here: https://curl.haxx.se/docs/sslcerts.html
+``` 
+
+V takovém případě stačí do vaší aplikace nainstalovat balíček [`composer/ca-bundle`](https://packagist.org/packages/composer/ca-bundle) a wrapper jej automaticky
+použije pro spojení se serverem.
+
+```sh
+composer require composer/ca-bundle
 ```

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "roave/security-advisories": "dev-master",
     "sllh/composer-versions-check": "^2.0"
   },
+  "suggest": {
+    "composer/ca-bundle": "Provide secure way to fix SSL error (SSL certificate problem: Invalid certificate)"
+  },
   "autoload": {
     "psr-4": {
       "Ecomailcz\\Webareal\\": ["src/"]

--- a/src/Client.php
+++ b/src/Client.php
@@ -145,6 +145,8 @@ class Client
             curl_setopt($curl, CURLOPT_XOAUTH2_BEARER, $apiToken);
         }
 
+        $this->connectCaBundle($curl);
+
         $responseContent = curl_exec($curl);
         if ($error = curl_error($curl)) {
             $curl_errno = curl_errno($curl);
@@ -210,5 +212,22 @@ class Client
             $response->getStatusCode(),
             $response
         );
+    }
+
+    /**
+     * @param resource $curl Curl resource
+     */
+    private function connectCaBundle($curl): void
+    {
+        if (class_exists(\Composer\CaBundle\CaBundle::class, true) === false) {
+            return;
+        }
+
+        $caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath();
+        if (is_dir($caPathOrFile)) {
+            curl_setopt($curl, CURLOPT_CAPATH, $caPathOrFile);
+        } else {
+            curl_setopt($curl, CURLOPT_CAINFO, $caPathOrFile);
+        }
     }
 }


### PR DESCRIPTION
Při použití knihovny na serveru, který neměl aktuální ca-certifikáty jsem doplnil jako volitelnou výbavu balíček `composer/ca-bundle`, který si nese vlastní udržovanou sadu ca-certifikátů.

