### PR TITLE
[Security bug] Fix bug with shared Token cache

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -72,7 +72,7 @@ class Client
 
     private function getApiToken(): string
     {
-        return $this->tokenCache->load() ?? $this->login();
+        return $this->tokenCache->load($this->credentials->getIdentityHash()) ?? $this->login();
     }
 
     private function login(): string
@@ -93,7 +93,7 @@ class Client
             );
         }
 
-        $this->tokenCache->save($response->getField('token'));
+        $this->tokenCache->save($this->credentials->getIdentityHash(), $response->getField('token'));
 
         return $response->getField('token');
     }

--- a/src/Credentials.php
+++ b/src/Credentials.php
@@ -79,4 +79,9 @@ class Credentials
     {
         return $this->apiKey;
     }
+
+    public function getIdentityHash(): string
+    {
+        return md5(serialize([$this->login, $this->password, $this->apiKey, $this->url]));
+    }
 }

--- a/src/TokenCache/CacheException.php
+++ b/src/TokenCache/CacheException.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Ecomailcz\Webareal\TokenCache;
 
-use Ecomailcz\Webareal\Exception\RuntimeException;
+use Ecomailcz\Webareal\Exception\LogicException;
 
-class CacheException extends RuntimeException
+class CacheException extends LogicException
 {
 
 }

--- a/src/TokenCache/FileCache.php
+++ b/src/TokenCache/FileCache.php
@@ -22,21 +22,22 @@ class FileCache implements ITokenCache
         $this->tempDir = $tempDir;
     }
 
-    public function load(): ?string
+    public function load(string $cacheKey): ?string
     {
         try {
-            return $this->loadFormFile();
+            return $this->loadFormFile($cacheKey);
         } catch (Exception $e) {
             return null;
         }
     }
 
     /**
+     * @param string $cacheKey
      * @param string $token
      * @param DateTimeInterface|null $expire
      * @throws CacheException
      */
-    public function save(string $token, ?DateTimeInterface $expire = null): void
+    public function save(string $cacheKey, string $token, ?DateTimeInterface $expire = null): void
     {
         if ($expire === null) {
             $expire = new DateTimeImmutable(self::DEFAULT_TTL);
@@ -53,7 +54,7 @@ class FileCache implements ITokenCache
         }
 
         $result = file_put_contents(
-            $this->getCacheFile(),
+            $this->getCacheFile($cacheKey),
             $json
         );
 
@@ -62,27 +63,28 @@ class FileCache implements ITokenCache
         }
     }
 
-    public function clear(): void
+    public function clear(string $cacheKey): void
     {
-        $file = $this->getCacheFile();
+        $file = $this->getCacheFile($cacheKey);
         if (is_file($file) && !unlink($file)) {
             throw new CacheException(sprintf('Unable to delete cache file: "%s"', $file));
         }
     }
 
-    private function getCacheFile(): string
+    private function getCacheFile(string $cacheKey): string
     {
-        return $this->tempDir . '/tokenCache.json';
+        return $this->tempDir . "/tokenCache_{$cacheKey}.json";
     }
 
     /**
+     * @param string $cacheKey
      * @return string|null
      * @throws JsonException
      * @throws Exception
      */
-    private function loadFormFile(): ?string
+    private function loadFormFile(string $cacheKey): ?string
     {
-        $file = $this->getCacheFile();
+        $file = $this->getCacheFile($cacheKey);
 
         $json = @file_get_contents($file); // intentionally @ - file nay not exists
         if ($json === false) {

--- a/src/TokenCache/ITokenCache.php
+++ b/src/TokenCache/ITokenCache.php
@@ -10,9 +10,9 @@ interface ITokenCache
 {
     public const DEFAULT_TTL = '+1 hour';
 
-    public function load(): ?string;
+    public function load(string $cacheKey): ?string;
 
-    public function save(string $token, ?DateTimeInterface $expire = null): void;
+    public function save(string $cacheKey, string $token, ?DateTimeInterface $expire = null): void;
 
-    public function clear(): void;
+    public function clear(string $cacheKey): void;
 }

--- a/src/TokenCache/MemoryCache.php
+++ b/src/TokenCache/MemoryCache.php
@@ -9,29 +9,30 @@ use DateTimeInterface;
 
 class MemoryCache implements ITokenCache
 {
-    /** @var string|null */
-    private $token;
-    /** @var DateTimeInterface|null */
-    private $expire;
+    /** @var string[] */
+    private $token = [];
+    /** @var DateTimeInterface[] */
+    private $expire = [];
 
-    public function load(): ?string
+    public function load(string $cacheKey): ?string
     {
-        if ($this->token !== null && $this->expire > new DateTimeImmutable()) {
-            return $this->token;
+        if (isset($this->token[$cacheKey]) && $this->expire[$cacheKey] > new DateTimeImmutable()) {
+            return $this->token[$cacheKey];
         }
 
         return null;
     }
 
-    public function save(string $token, ?DateTimeInterface $expire = null): void
+    public function save(string $cacheKey, string $token, ?DateTimeInterface $expire = null): void
     {
-        $this->expire = $expire ?? new DateTimeImmutable(self::DEFAULT_TTL);
-        $this->token = $token;
+        $this->expire[$cacheKey] = $expire ?? new DateTimeImmutable(self::DEFAULT_TTL);
+        $this->token[$cacheKey] = $token;
     }
 
-    public function clear(): void
+    public function clear(string $cacheKey): void
     {
-        $this->token = null;
-        $this->expire = null;
+        if (isset($this->token[$cacheKey])) {
+            unset($this->token[$cacheKey], $this->expire[$cacheKey]);
+        }
     }
 }


### PR DESCRIPTION
Pokud je knihovna používána pro připojení více než jedné identity, je autorizační token nesprávně sdílen napříč identitami a tedy dochází k nežádoucímu přihlášení jen k jedné z nich, ostatní jsou ignorovány. Zároveň je to bezpečnostní chyba, protože umožňuje skrytě přihlášení k jiné identitě, než pro kterou má aplikace v credentials.

PR přidává pro všechny metody cache nový povinný klíč `$cacheKey`, podle kterého se cache ukládá i hledá, hashi je předkládána. Klíč je pak generován jako hash credentials, které se knihovně předávají.

